### PR TITLE
fix orders by multiple fields

### DIFF
--- a/core/query.js
+++ b/core/query.js
@@ -114,7 +114,7 @@ class Query {
             conditions.push(`WHERE ${this.where(options.where)}`);
         }
         if (options.order) {
-            conditions.push(`ORDER BY ${_.reduce(options.order, (carry, field) => carry += _.isArray(field) ? field.join(' ') : field, '')}`);
+            conditions.push(`ORDER BY ${_.reduce(options.order, (carry, field) => carry += (carry === '' ? '' : ', ') + (_.isArray(field) ? field.join(' ') : field) , '')}`);
         }
         if (options.group) {
             conditions.push(`GROUP BY ${options.group.join(', ')}`);


### PR DESCRIPTION
example
query before:
```sql
...' INNER JOIN programs programs ON programs.id = schedules.id_program 
WHERE programs.id_program_type = 2 AND schedules.start > 9360 
ORDER BY start ASCend DESC 
LIMIT 1'
```
query after:
```sql
...' INNER JOIN programs programs ON programs.id = schedules.id_program 
WHERE programs.id_program_type = 2 AND schedules.start > 9360 
ORDER BY start ASC, end DESC 
LIMIT 1'
```