### PR TITLE
Change sequelize-automate url

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "mysql2": "^2.3.3",
     "pluralize": "^8.0.0",
     "sequelize": "^6.23.0",
-    "sequelize-automate": "git+https://package:ngpDwV2ME8WuYRDoQTxM@gitlab.com/steplix/sequelize-automate.git#master"
+    "sequelize-automate": "git+https://github.com/steplix/sequelize-automate.git#master"
   },
   "devDependencies": {
     "chai": "^4.3.6",


### PR DESCRIPTION
This pr fixes the url of the dependency sequelize-automate, previously pointing to gitlab.